### PR TITLE
送信ボタンの表示変更

### DIFF
--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -141,7 +141,7 @@ ja:
     select:
       prompt: 選択してください
     submit:
-      create: 登録する
+      create: Send
       submit: 保存する
       update: 更新する
   number:


### PR DESCRIPTION
# What
送信した際に「Send」の表示が「登録する」になるのを「Send」のままにした
(ja.ymlファイルのsubmitのcreateを「登録する」から「Send」へ変更)

# Why
送信の際にビューが崩れてしまうのを防ぐため